### PR TITLE
Fix ESM __dirname usage for Text default font path

### DIFF
--- a/src/core/mobjects/text/Text.ts
+++ b/src/core/mobjects/text/Text.ts
@@ -1,11 +1,13 @@
 import * as fontkit from 'fontkit';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { Color } from '../../math';
 import { VGroup } from '../VGroup';
 import { centerGroup } from '../VGroup/layout';
 import { Glyph } from './Glyph';
 
-const DEFAULT_FONT_PATH = resolve(join(__dirname, '..', '..', 'font', 'ComicSansMS3.ttf'));
+const THIS_FILE_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_FONT_PATH = resolve(join(THIS_FILE_DIR, '..', '..', 'font', 'ComicSansMS3.ttf'));
 
 /**
  * A VGroup of vectorized glyphs created from a text string using fontkit.


### PR DESCRIPTION
### Motivation
- The project is built/used as ESM (`"type": "module"`) and `Text.ts` relied on `__dirname`, which is undefined in ESM and caused a `ReferenceError` when resolving the default font path at runtime.

### Description
- Replace `__dirname` with an ESM-safe directory calculation using `fileURLToPath(import.meta.url)` and `dirname(...)`, import `fileURLToPath` from `url`, and update `DEFAULT_FONT_PATH` to resolve from `THIS_FILE_DIR` while preserving the original relative path.

### Testing
- Ran `bun run typecheck`, which completed successfully.
- Ran `bun test tests/unit/mobjects/VGroup.test.ts`, and all tests passed.

------
## Summary by Sourcery

Bug Fixes:
- Resolve the default Text font path using an ESM-safe directory calculation instead of __dirname to prevent runtime ReferenceError in ESM builds.